### PR TITLE
game_list_worker: Fix game list subdirectory scanning

### DIFF
--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -369,8 +369,8 @@ void GameListWorker::run() {
             auto* const game_list_dir = new GameListDir(game_dir);
             emit DirEntryReady(game_list_dir);
             provider->ClearAllEntries();
-            ScanFileSystem(ScanTarget::FillManualContentProvider, game_dir.path.toStdString(), 2,
-                           game_list_dir);
+            ScanFileSystem(ScanTarget::FillManualContentProvider, game_dir.path.toStdString(),
+                           game_dir.deep_scan ? 256 : 0, game_list_dir);
             ScanFileSystem(ScanTarget::PopulateGameList, game_dir.path.toStdString(),
                            game_dir.deep_scan ? 256 : 0, game_list_dir);
         }


### PR DESCRIPTION
Oddly enough the scan that feeds the manual content provider is hardcoded to scan 2 nested directories deep.
This effectively rendered the scan subdirectories setting useless as the manual content provider cannot find any games located more than 2 nested directories deep.
Furthermore, this behavior causes game files to be picked up by the manual content provider even if scan subdirectories is disabled.

FIx this by utilizing the behavior described when populating the game list for populating the content provider.